### PR TITLE
Current ReactNativeAndroid needs additional process to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ A React Native library for Fabric, Crashlytics and Answers`
   + project(':react-native-fabric').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-fabric/android')
   ```
 
+* Edit `android/build.gradle` (note: **android** folder) to look like this:
+
+```diff
+allprojects {
+    repositories {
+        mavenLocal()
+        jcenter()
++         maven { url 'https://maven.fabric.io/public' }
+    }
+}
+```
+
 * Edit `android/app/build.gradle` (note: **app** folder) to look like this: 
 
   ```diff


### PR DESCRIPTION
With react-native 0.20.0 and react-native-fabric 0.0.2, Gradle sync is failed.
![_2016-02-24_12_25_01](https://cloud.githubusercontent.com/assets/434227/13274829/cbc8b836-daf1-11e5-9bac-8365ca2df6ee.png)

I tryed to add fabric repository into android/build.gradle, yes it works.

It seems that repositories settings depends parent project settings.