### PR TITLE
fixes or related to #10 #13 #15 #20 #22 #21

### DIFF
--- a/Crashlytics.js
+++ b/Crashlytics.js
@@ -53,6 +53,10 @@ module.exports = {
     SMXCrashlytics.recordError(newError);
   },
 
+  logException: function (value:string) {
+    SMXCrashlytics.logException(value);
+  },
+
   log: function (message:string) {
     SMXCrashlytics.log(message);
   },

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A React Native library for Fabric, Crashlytics and Answers
 
 - Set up Fabric / Crashlytics in your app as instructed on [Fabric.io](https://fabric.io)
 
-- Alternatively if you don't use Android studio you also need to follow the steps described in 'Android without Android Studio' **as well as** the steps in 'Android'.
+- Alternatively if you don't use Android studio you also need to follow the steps described in [`Android without Android Studio`](#no_android_studio) **as well as** the steps in [`Android`](#android).
 
 ### iOS
  
@@ -20,6 +20,7 @@ A React Native library for Fabric, Crashlytics and Answers
 - Find and add `libSMXCrashlytics.a` under the `Workspace` group
 - ⌘+B
 
+<a name="android"></a>
 ### Android
 
 *Note: Android support requires React Native 0.16 or later 
@@ -88,9 +89,10 @@ A React Native library for Fabric, Crashlytics and Answers
   }
   ```
 
+<a name="no_android_studio"></a>
 ### Android without Android Studio
 
-Make sure you also follow the steps described in the previous section 'Android'.
+Make sure you also follow the steps described in [`Android`](#android).
 
 * Edit your `build.gradle` (note: **app** folder) to look like this.
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ A React Native library for Fabric, Crashlytics and Answers
 
 Make sure you also follow the steps described in [`Android`](#android).
 
-* Edit your `build.gradle` (note: **app** folder) to look like this.
+* Edit your `build.gradle` (note: **app** folder) to look like this:
 
-```
+  ```diff
   apply plugin: "com.android.application"
 
   + buildscript {
@@ -122,11 +122,11 @@ Make sure you also follow the steps described in [`Android`](#android).
   +         transitive = true;
   +     }
   }
-```
+  ```
 
 * Edit your `MainActivity.java` (deep in `android/app/src/main/java/...`) to look like this (note **two** places to edit):
 
-```
+  ```diff
   + import android.os.Bundle;
   + import com.crashlytics.android.Crashlytics;
   + import io.fabric.sdk.android.Fabric;
@@ -142,12 +142,11 @@ Make sure you also follow the steps described in [`Android`](#android).
     [...]
 
   }
-
-```
+  ```
 
 * Edit your `AndroidManifest.xml` (in `android/app/src/main/`) to look like this. Make sure to enter your fabric API key after `android:value=`, you can find your key on your fabric organisation page.
 
-```
+  ```diff
   <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       [...]
       <application
@@ -159,7 +158,7 @@ Make sure you also follow the steps described in [`Android`](#android).
       </application>
   +   <uses-permission android:name="android.permission.INTERNET" />
   </manifest>
-```
+  ```
 
 ## Crashlytics Usage
 To see all available methods take a look at [Crashlytics.js](https://github.com/corymsmith/react-native-fabric/blob/master/Crashlytics.js)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A React Native library for Fabric, Crashlytics and Answers
 
 - Set up Fabric / Crashlytics in your app as instructed on [Fabric.io](https://fabric.io)
 
-- Alternatively if you don't use Android studio you also need to follow the steps described in [`Android without Android Studio`](#no_android_studio) **as well as** the steps in [`Android`](#android).
+- Alternatively for Android, if you **don't** use Android studio you can skip the first step and instead follow the steps described in [`Android`](#android) **as well as** the steps in [`Android without Android Studio`](#no_android_studio).
 
 ### iOS
  
@@ -60,32 +60,14 @@ A React Native library for Fabric, Crashlytics and Answers
   + import com.smixx.fabric.FabricPackage;
 
   ....
-
-  public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
-
-    private ReactInstanceManager mReactInstanceManager;
-    private ReactRootView mReactRootView;
-
+  public class MainActivity extends ReactActivity {
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-      super.onCreate(savedInstanceState);
-      mReactRootView = new ReactRootView(this);
-
-      mReactInstanceManager = ReactInstanceManager.builder()
-        .setApplication(getApplication())
-        .setBundleAssetName("index.android.bundle")
-        .setJSMainModuleName("index.android")
-        .addPackage(new MainReactPackage())
-  +     .addPackage(new FabricPackage(this))
-        .setUseDeveloperSupport(BuildConfig.DEBUG)
-        .setInitialLifecycleState(LifecycleState.RESUMED)
-        .build();
-
-      mReactRootView.startReactApplication(mReactInstanceManager, "MyApp", null);
-
-      setContentView(mReactRootView);
+    protected List<ReactPackage> getPackages() {
+        return Arrays.<ReactPackage>asList(
+  +         new FabricPackage(this),
+            new MainReactPackage()
+        );
     }
-    ...
   }
   ```
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ A React Native library for Fabric, Crashlytics and Answers
 
 - Set up Fabric / Crashlytics in your app as instructed on [Fabric.io](https://fabric.io)
 
+- Alternatively if you don't use Android studio you also need to follow the steps described in 'Android without Android Studio' **as well as** the steps in 'Android'.
+
 ### iOS
  
 - Open your project in Xcode
@@ -86,6 +88,77 @@ A React Native library for Fabric, Crashlytics and Answers
   }
   ```
 
+### Android without Android Studio
+
+Make sure you also follow the steps described in the previous section 'Android'.
+
+* Edit your `build.gradle` (note: **app** folder) to look like this.
+
+```
+  apply plugin: "com.android.application"
+
+  + buildscript {
+  +   repositories {
+  +     maven { url 'https://maven.fabric.io/public' }
+  +   }
+  +   dependencies {
+  +     // The Fabric Gradle plugin uses an open ended version to react
+  +     // quickly to Android tooling updates
+  +     classpath 'io.fabric.tools:gradle:1.+'
+  +   }
+  + }
+  + apply plugin: 'io.fabric'
+  + repositories {
+  +   maven { url 'https://maven.fabric.io/public' }
+  + }
+
+  [...]
+
+  dependencies {
+      [...]
+  +     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
+  +         transitive = true;
+  +     }
+  }
+```
+
+* Edit your `MainActivity.java` (deep in `android/app/src/main/java/...`) to look like this (note **two** places to edit):
+
+```
+  + import android.os.Bundle;
+  + import com.crashlytics.android.Crashlytics;
+  + import io.fabric.sdk.android.Fabric;
+
+  public class MainActivity extends ReactActivity {
+
+  +   @Override
+  +   protected void onCreate(Bundle savedInstanceState) {
+  +       super.onCreate(savedInstanceState);
+  +       Fabric.with(this, new Crashlytics());
+  +   }
+
+    [...]
+
+  }
+
+```
+
+* Edit your `AndroidManifest.xml` (in `android/app/src/main/`) to look like this. Make sure to enter your fabric API key after `android:value=`, you can find your key on your fabric organisation page.
+
+```
+  <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+      [...]
+      <application
+        [...]
+  +       <meta-data
+  +         android:name="io.fabric.ApiKey"
+  +         android:value=[YOUR API KEY]
+  +       />
+      </application>
+  +   <uses-permission android:name="android.permission.INTERNET" />
+  </manifest>
+```
+
 ## Crashlytics Usage
 To see all available methods take a look at [Crashlytics.js](https://github.com/corymsmith/react-native-fabric/blob/master/Crashlytics.js)
 
@@ -112,6 +185,9 @@ Crashlytics.recordError('something went wrong!');
 
 // Due to differences in primitive types between iOS and Android I've exposed a setNumber function vs. setInt, setFloat, setDouble, setLong, etc                                        
 Crashlytics.setNumber('post_count', 5);
+
+// Record a non-fatal JS error on Android
+Crashlytics.logException('');
 
 ```
 

--- a/android/src/main/java/com/smixx/fabric/SMXCrashlytics.java
+++ b/android/src/main/java/com/smixx/fabric/SMXCrashlytics.java
@@ -27,6 +27,11 @@ public class SMXCrashlytics extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void logException(String value) {
+        Crashlytics.logException(new RuntimeException(value));
+    }
+
+    @ReactMethod
     public void log(String message) {
         Crashlytics.log(message);
     }


### PR DESCRIPTION
All of these changes are for android
* updated documentation to reflect new 'ReactActivity' in MainActivity.java instead of 'Activity'
* added documentation instructions to install react-native-fabric on non-Android Studio projects
* added logException method for use instead of recordError since the latter doesn't work on android

fixes or related to #10 #13 #15 #20 #22 #21 