### PR TITLE
Fix Crashlytics.recordError('string')

### DIFF
--- a/Crashlytics.js
+++ b/Crashlytics.js
@@ -23,7 +23,7 @@ module.exports = {
     var newError;
 
     if (typeof error === "string" || error instanceof String) {
-      newError = {message: error};
+      newError = {domain: error};
     }
     else if (typeof error === "number") {
       newError = {code: error};


### PR DESCRIPTION
Fixes #27 

Why:

* We want string messages to properly be tracked in Fabric/Crashlytics.

This change addresses the need by:

* Changing the key when the parameter is a string from `message` to
  `domain` so that it maps properly in the Obj-C file.