### PR TITLE
adding search path for older react native applications

### DIFF
--- a/ios/SMXCrashlytics.xcodeproj/project.pbxproj
+++ b/ios/SMXCrashlytics.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/../example/ios",
 					"$(SRCROOT)/../../../ios",
+					"$(SRCROOT)/../../../",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -206,6 +207,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SRCROOT)/../example/ios",
 					"$(SRCROOT)/../../../ios",
+					"$(SRCROOT)/../../../",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
Our application was created before the `ios` folder standard and all that react native was was ios only. 

We placed our frameworks in the standard location and when I tried to use library it wasn't able to find the locations, this PR simply updates where the application should look for Frameworks like Crashlytics that this app is dependent on. 