### PR TITLE
Removes deprecated method

### DIFF
--- a/Crashlytics.js
+++ b/Crashlytics.js
@@ -11,48 +11,6 @@ module.exports = {
   crash: SMXCrashlytics.crash,
   throwException: SMXCrashlytics.throwException,
 
-  /**
-   * Convert error into something the native code knows what to do with.
-   * Attempts to be flexible and accept error objects in different formats.
-   * We need to be careful which data types we send to the native layer.
-   * Could do something much fancier here, e.g., deep, recursive serialization
-   * (or "flattening") but keep it simple for now.
-   * @param error
-   */
-  recordError: function (error) {
-    var newError;
-
-    if (typeof error === "string" || error instanceof String) {
-      newError = {domain: error};
-    }
-    else if (typeof error === "number") {
-      newError = {code: error};
-    }
-    else if (typeof error === "object") {
-      newError = {};
-
-      // Pass everything in as a string or number to be safe
-      for (var k in error) {
-        if (error.hasOwnProperty(k)) {
-          if (((typeof error[k]) !== "number") && ((typeof error[k]) !== "string") && !(error[k] instanceof String)) {
-            newError[k] = JSON.stringify(error[k]);
-          }
-          else {
-            newError[k] = error[k]
-          }
-        }
-      }
-    }
-    else {
-      // Array?
-      // Fall back on JSON
-      newError = {
-        json: JSON.stringify(error)
-      }
-    }
-    SMXCrashlytics.recordError(newError);
-  },
-
   logException: function (value:string) {
     SMXCrashlytics.logException(value);
   },

--- a/ios/SMXCrashlytics/SMXCrashlytics.m
+++ b/ios/SMXCrashlytics/SMXCrashlytics.m
@@ -19,23 +19,6 @@ RCT_EXPORT_METHOD(log:(NSString *)message)
   CLS_LOG(@"%@", message);
 }
 
-RCT_EXPORT_METHOD(recordError:(NSDictionary *)error)
-{
-    NSInteger *code;
-    NSString *domain;
-    if ([error objectForKey:@"code"])
-        code = [error[@"code"] intValue];
-    else
-        code = DefaultCode;
-    if ([error objectForKey:@"domain"])
-        domain = [error valueForKey:@"domain"];
-    else
-        domain = DefaultDomain;
-
-    NSError *error2 = [NSError errorWithDomain:domain code:code userInfo:error];
-    [[Crashlytics sharedInstance] recordError:error2];
-}
-
 RCT_EXPORT_METHOD(crash)
 {
   [[Crashlytics sharedInstance] crash];


### PR DESCRIPTION
`reportError` has been removed in the latest SDK.

It appears that it is suggested to use `Answers` for this type of reporting.