### PR TITLE
add error name and reason to logException in recordCustomExceptionName

### DIFF
--- a/android/src/main/java/com/smixx/fabric/SMXCrashlytics.java
+++ b/android/src/main/java/com/smixx/fabric/SMXCrashlytics.java
@@ -91,7 +91,7 @@ public class SMXCrashlytics extends ReactContextBaseJavaModule {
             StackTraceElement stack = new StackTraceElement("", functionName, map.getString("fileName"), map.getInt("lineNumber"));
             stackTrace[i] = stack;
         }
-        Exception e = new Exception();
+        Exception e = new Exception(name + "\n" + reason);
         e.setStackTrace(stackTrace);
         Crashlytics.logException(e);
     }


### PR DESCRIPTION
The name and reason are not used. So I just put it into the construction of java Exception.
Should be a little more helpful.