### PR TITLE
Add Separate Twitter Kit Repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A React Native library for Fabric, Crashlytics and Answers
 
 [![NPM](https://nodei.co/npm/react-native-fabric.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/react-native-fabric/)
 
+For Twitter Kit support, see [react-native-fabric-twitterkit](https://github.com/tkporter/react-native-fabric-twitterkit)
+
 ## Installation
 
 - Set up Fabric / Crashlytics in your app as instructed on [Fabric.io](https://fabric.io)


### PR DESCRIPTION
[Here's the repo](https://github.com/tkporter/react-native-fabric-twitterkit)

I know that you didn't want to directly add TwitterKit support into the master repo as people would have to install the TwitterKit/TwitterCore Pods and android SDKs. With an entirely separate repo, we avoid the fact that the twitterkit branch of react-native-fabric is a multitude of commits behind master.

What's new with this repo:

Essentially everything from the SMXTwitter component in the twitterkit branch is there, however I made adjustments with callbacks for Android and I implemented the previously-missing `composeTweet` for iOS.

I just want to ensure that everything will stay up to date with each other even when new commits are merged into master on react-native-fabric.

Thanks for keeping this repo active and doing all you do!