### PR TITLE
Avoid error with logException and recordError

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,14 +224,14 @@ Crashlytics.setString('organization', 'Acme. Corp');
 // Forces a native crash for testing
 Crashlytics.crash();
 
-// Record a non-fatal JS error
-Crashlytics.recordError('something went wrong!');
-
 // Due to differences in primitive types between iOS and Android I've exposed a setNumber function vs. setInt, setFloat, setDouble, setLong, etc                                        
 Crashlytics.setNumber('post_count', 5);
 
-// Record a non-fatal JS error on Android
+// Record a non-fatal JS error only on Android
 Crashlytics.logException('');
+
+// Record a non-fatal JS error only on iOS
+Crashlytics.recordError('something went wrong!');
 
 ```
 


### PR DESCRIPTION
Since the problem between this two functions is not solved, I think it's better to update the documentation to avoid errors with the platforms.