### PR TITLE
Fix code passing in recordError

### DIFF
--- a/ios/SMXCrashlytics/SMXCrashlytics.m
+++ b/ios/SMXCrashlytics/SMXCrashlytics.m
@@ -23,8 +23,9 @@ RCT_EXPORT_METHOD(recordError:(NSDictionary *)error)
 {
     NSInteger *code;
     NSString *domain;
-    if ([error objectForKey:@"code"])
-        code = [error[@"code"] intValue];
+    NSObject *codeObject = [error objectForKey:@"code"];
+    if (codeObject && [codeObject isKindOfClass:NSNumber.class])
+        code = [(NSNumber *)codeObject intValue];
     else
         code = DefaultCode;
     if ([error objectForKey:@"domain"])


### PR DESCRIPTION
This PR fixes a bug where `code` is assumed to always be a number and is being incorrectly parsed.