### PR TITLE
Fix issue with using ReactNativeFabric in a project that has use_frameworks! turned on.

### DIFF
--- a/ReactNativeFabric.podspec
+++ b/ReactNativeFabric.podspec
@@ -18,6 +18,10 @@ Pod::Spec.new do |s|
   s.dependency 'React'
   s.dependency 'Fabric'
   s.dependency 'Crashlytics'
+  s.ios.xcconfig = {
+    'FRAMEWORK_SEARCH_PATHS' => '"${PODS_ROOT}/Crashlytics/iOS" "${PODS_ROOT}/Fabric/iOS"',
+    'OTHER_LDFLAGS' => '-framework Crashlytics -framework Fabric'
+  }
 
   s.preserve_paths      = 'README.md', 'LICENSE', 'package.json'
   s.source_files        = 'ios/**/*.{h,m}'


### PR DESCRIPTION
I'm not sure if this is something that should be in the main repo, as I've only tested it for our setup (which builds all pods as frameworks)

Tested with:
Cocoapods 1.1.1
ReactNativeFabric 0.3.2
Crashlytics 3.8.3
Fabric 1.6.11

https://github.com/CocoaPods/CocoaPods/issues/1824 suggests that this might still be an issue in Cocoapods. See #76 for other possible solutions to this problem