### PR TITLE
Add Framework search path for Cocoapods

### DIFF
--- a/ios/SMXCrashlytics.xcodeproj/project.pbxproj
+++ b/ios/SMXCrashlytics.xcodeproj/project.pbxproj
@@ -234,6 +234,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 					"$(SRCROOT)/../../../ios/Crashlytics",
+					"$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -254,6 +255,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 					"$(SRCROOT)/../../../ios/Crashlytics",
+					"$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
As detailed in a [comment](https://github.com/corymsmith/react-native-fabric/issues/76#issuecomment-259815991) for issue #76, when using Cocoapods with use_frameworks!, the file 'Crashlytics/Crashlytics.h' doesn't get found. 

The issue is fixed by adding $(SRCROOT)/../../../ios/Pods/Crashlytics/iOS to Framework search paths. 

I believe this should be in the repo as there is already an analogous Header search path for the case use_frameworks! disabled.