### PR TITLE
Fix logStartCheckout argument order on iOS

### DIFF
--- a/ios/SMXCrashlytics/SMXAnswers.m
+++ b/ios/SMXCrashlytics/SMXAnswers.m
@@ -75,8 +75,8 @@ RCT_EXPORT_METHOD(logAddToCart:(nullable NSString *)itemPriceOrNil
 }
 
 RCT_EXPORT_METHOD(logStartCheckout:(nullable NSString *)totalPriceOrNil
-                  currency:(nullable NSString *)currencyOrNil
                   itemCount:(nullable NSString *)itemCountOrNil
+                  currency:(nullable NSString *)currencyOrNil
                   customAttributes:(nullable ANS_GENERIC_NSDICTIONARY(NSString *, id) *)customAttributesOrNil){
   [Answers logStartCheckoutWithPrice:[self getDecimalFromString:totalPriceOrNil] currency:currencyOrNil itemCount:[self getIntegerFromString:itemCountOrNil] customAttributes:customAttributesOrNil];
 }


### PR DESCRIPTION
The argument order in the ObjC implementation is out of sync with java and javascript. This PR fixes that, but is potentially breaking for existing installations using the wrong argument order (although I never got it to work that way either so I'm guessing no-one is using it). 