### PR TITLE
Update to lastest grade version 2.2.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 


### PR DESCRIPTION
Gets rid of the compile warnings: 

Unknown source file : warning: string 'catalyst_debugjs' has no default translation.
Unknown source file : warning: string 'catalyst_element_inspector' has no default translation.
Unknown source file : warning: string 'catalyst_jsload_error' has no default translation.
Unknown source file : warning: string 'catalyst_jsload_message' has no default translation.
Unknown source file : warning: string 'catalyst_jsload_title' has no default translation.
Unknown source file : warning: string 'catalyst_reloadjs' has no default translation.
Unknown source file : warning: string 'catalyst_settings' has no default translation.
Unknown source file : warning: string 'catalyst_settings_title' has no default translation.