### PR TITLE
Make Framework Search Paths more permissive.

### DIFF
--- a/ios/SMXCrashlytics.xcodeproj/project.pbxproj
+++ b/ios/SMXCrashlytics.xcodeproj/project.pbxproj
@@ -314,8 +314,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(SRCROOT)/../../../ios/Crashlytics",
-					"$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS",
+					"$(SRCROOT)/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -335,8 +334,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(SRCROOT)/../../../ios/Crashlytics",
-					"$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS",
+					"$(SRCROOT)/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
### Change
- `$(SRCROOT)/../../../ios/Crashlytics`
- `$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS`
### Into
- `$(SRCROOT)/../../../ios/**`

To allow users to store their Fabric frameworks anywhere inside their projects.

(For example I store all my manual frameworks in `ios/ManualFrameworks`)