### PR TITLE
Remove createJSModules - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -19,6 +19,10 @@ public class FabricPackage implements ReactPackage {
         modules.add(new SMXAnswers(reactContext));
         return modules;
     }
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+        return Collections.emptyList();		
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -21,11 +21,6 @@ public class FabricPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return new ArrayList<>();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();
     }

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -21,8 +21,8 @@ public class FabricPackage implements ReactPackage {
     }
     
     // Deprecated RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {		
-        return Collections.emptyList();		
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return new ArrayList<>();		
     }
 
     @Override

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -19,10 +19,10 @@ public class FabricPackage implements ReactPackage {
         modules.add(new SMXAnswers(reactContext));
         return modules;
     }
-    
+
     // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return new ArrayList<>();		
+        return new ArrayList<>();
     }
 
     @Override

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -20,6 +20,7 @@ public class FabricPackage implements ReactPackage {
         return modules;
     }
     
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {		
         return Collections.emptyList();		
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method.