### PR TITLE
Revert "Make Framework Search Paths more permissive."

### DIFF
--- a/ios/SMXCrashlytics.xcodeproj/project.pbxproj
+++ b/ios/SMXCrashlytics.xcodeproj/project.pbxproj
@@ -318,7 +318,8 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../ios/Crashlytics",
+					"$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -338,7 +339,8 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
-					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../ios/Crashlytics",
+					"$(SRCROOT)/../../../ios/Pods/Crashlytics/iOS",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Revert 3949d35968f9dbdf57458860b1f8b1f4b9c2f2a3
fix ` 'Crashlytics/Crashlytics.h' file not found` on 0.5.0