### PR TITLE
Update build.gradle to latest versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.49.3'
+    compile 'com.facebook.react:react-native:+'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,12 +11,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 26
     buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName '1.0'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    compile 'com.facebook.react:react-native:0.49.3'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
         transitive = true
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,6 @@ repositories {
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
-        transitive = true;
+        transitive = true
     }
 }

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -19,6 +19,11 @@ public class FabricPackage implements ReactPackage {
         modules.add(new SMXAnswers(reactContext));
         return modules;
     }
+    
+    // Deprecated RN 0.47
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+         return new ArrayList<>();
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -20,11 +20,6 @@ public class FabricPackage implements ReactPackage {
         return modules;
     }
 
-    // Deprecated RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return new ArrayList<>();
-    }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return new ArrayList<>();

--- a/android/src/main/java/com/smixx/fabric/FabricPackage.java
+++ b/android/src/main/java/com/smixx/fabric/FabricPackage.java
@@ -19,10 +19,10 @@ public class FabricPackage implements ReactPackage {
         modules.add(new SMXAnswers(reactContext));
         return modules;
     }
-    
+
     // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
-         return new ArrayList<>();
+        return new ArrayList<>();
     }
 
     @Override


### PR DESCRIPTION
A solution to #115.

The current build.gradle uses old versions of Android and build tools. It also uses a wild card for the RN version which can cause issues when there are breaking changes to the platform (e.g. the removal of `ReactPackage.createJSModules()` method in RN 0.47).
In the same token I removed the unused method from the FabricPackage class.