### PR TITLE
Create TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,69 @@
+export interface CustomAttributes {
+  [index: string]: string;
+}
+
+declare namespace Answers {
+
+  function logCustom(eventName: string, customAttributes?: CustomAttributes): void;
+  function logInvite(method: string, customAttributes?: CustomAttributes): void;
+  function logLevelStart(levelName: string, customAttributes?: CustomAttributes): void;
+  function logLevelEnd(levelName: string, customAttributes?: CustomAttributes): void;
+  function logLogin(method: string, success: boolean, customAttributes?: CustomAttributes): void;
+  function logSearch(query: string, customAttributes?: CustomAttributes): void;
+  function logSignUp(method: string, success: boolean, customAttributes?: CustomAttributes): void;
+  function logShare(
+    method: string,
+    contentName: string,
+    contentType: string,
+    contentId: string,
+    customAttributes?: CustomAttributes): void;
+  function logStartCheckout(
+    totalPrice: number,
+    count: number,
+    currency: string,
+    customAttributes?: CustomAttributes): void
+  function logAddToCart(
+    itemPrice: number,
+    currency: string,
+    itemName: string,
+    itemType: string,
+    itemId: string,
+    customAttributes?: CustomAttributes): void;
+  function logPurchase(
+    itemPrice: number,
+    currency: string,
+    success: boolean,
+    itemName: string,
+    itemType: string,
+    itemId: string,
+    customAttributes?: CustomAttributes): void;
+  function logContentView(
+    contentName: string,
+    contentType: string,
+    contentId: string,
+    customAttributes?: CustomAttributes): void;
+  function logRating(
+    rating: number,
+    contentId: string,
+    contentType: string,
+    contentName: string,
+    customAttributes?: CustomAttributes): void;
+
+}
+
+declare namespace Crashlytics {
+
+  function crash(): void;
+  function throwException(): void;
+  function recordError(error: any): void;
+  function logException(value: string): void;
+  function log(message: string): void;
+  function setUserEmail(email: string | null): void;
+  function setUserIdentifier(id: string | null): void;
+  function setUserName(userName: string | null): void;
+  function setBool(key: string, value: boolean): void;
+  function setNumber(key: string, value: number): void;
+  function setString(key: string, value: string): void;
+  function recordCustomExceptionName(name: string, reason: string, stack?: any[]): void;
+
+}


### PR DESCRIPTION
Create [TypeScript](https://www.typescriptlang.org/docs/home.html) definitions for the project. TypeScript adds type definitions in a fashion similar to Flow. Packages can declare global types for other projects to refer to when being used as a dependency.

This file simply takes `Answers.js` and `Crashlytics.js` and redefines their function signatures in a globally exported TypeScript typing file.