### PR TITLE
Fix Android build tools version to support the latest Android studio (3.0+)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.1'
+    buildToolsVersion '26.0.2'
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Hi, is this package still supported? Do you mind publishing the maintenance update? 