### PR TITLE
Update the crashlytics version number in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Make sure you also follow the steps described in [`Android`](#android).
 
   dependencies {
       [...]
-  +     compile('com.crashlytics.sdk.android:crashlytics:2.5.5@aar') {
+  +     compile('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
   +         transitive = true;
   +     }
   }


### PR DESCRIPTION
Fixes #174 

Crashlytics SDK version was incremented in 9d432c2408236049bb87bd319e3fddf69da6be8c but the README was not updated to have developers depend on the new version. Not a major issue, as the gradle would have resolved to the new version in our `build.gradle`, but still confusing for developers.