### PR TITLE
Remove recursive header search path

### DIFF
--- a/ios/SMXCrashlytics.xcodeproj/project.pbxproj
+++ b/ios/SMXCrashlytics.xcodeproj/project.pbxproj
@@ -326,7 +326,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../ios/Pods/Headers/Public/Crashlytics",
 					"$(SRCROOT)/../../../ios/Crashlytics/**",
-					"$(SRCROOT)/../../../ios/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -348,7 +347,6 @@
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../ios/Pods/Headers/Public/Crashlytics",
 					"$(SRCROOT)/../../../ios/Crashlytics/**",
-					"$(SRCROOT)/../../../ios/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
It resulted in an "Argument list too long: recursive header expansion failed." error when archiving (via Xcode) an app that has react-native-fabric as a dependency.