### PR TITLE
fix Attributes values

### DIFF
--- a/typings/react-native-fabric.d.ts
+++ b/typings/react-native-fabric.d.ts
@@ -151,7 +151,7 @@ declare module 'react-native-fabric' {
      * A key/value pair of strings.
      */
     interface Attributes {
-        [index: string]: String;
+        [index: string]: string | number;
     } 
 
     var Fabric: Fabric;


### PR DESCRIPTION
Per the Fabric SDK docs, the value of the Attributes sent to Fabric in a custom event can be a string or a number.  I updated the types to reflect this

https://docs.fabric.io/apple/answers/answers-events.html#custom-attributes