### PR TITLE
Update Android gradle configuration to conform to gradle 4.4

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.4'
     }
 }
 
@@ -56,8 +56,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
-    compile('com.crashlytics.sdk.android:crashlytics:2.9.2@aar') {
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNative', '+')}"
+    implementation("com.crashlytics.sdk.android:crashlytics:2.9.5@aar") {
         transitive = true;
     }
 }


### PR DESCRIPTION
`compile` and `compileOnly` were deprecated in Gradle 3, and finally removed in Gradle 4.4

Also:
- Update build tools to the latest on 3.1.x series
- Update Crashlytics SDK dependency to the latest release
