### PR TITLE
Fix: resolve dependencies from google repo first

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,11 +13,12 @@ allprojects {
 buildscript {
     repositories {
         google()
-        jcenter()
-        maven {
+         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
+       
     }
 
     dependencies {


### PR DESCRIPTION
-Reverse repo order, google then jcenter. 
Fixe: breaking builds where jcenter had a POM but the artifact is not found.
