### PR TITLE
In SMXCrashlytics.m, replace use of CLS_LOG with calls to CLSNSLog or…

### DIFF
--- a/ios/SMXCrashlytics/SMXCrashlytics.m
+++ b/ios/SMXCrashlytics/SMXCrashlytics.m
@@ -16,7 +16,11 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(log:(NSString *)message)
 {
-  CLS_LOG(@"%@", message);
+#if DEBUG
+    CLSNSLog(@"%@", message);
+#else
+    CLSLog(@"%@", message);
+#endif
 }
 
 RCT_EXPORT_METHOD(recordError:(NSDictionary *)error)


### PR DESCRIPTION
… CLSLog to avoid useless prefix info being added to every log message.